### PR TITLE
Fix rainbow out of buffer issue

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -418,7 +418,7 @@ void CPlayer::Snap(int SnappingClient)
 			Msg.m_aUseCustomColors[p] = 1;
 			Msg.m_aSkinPartColors[p] = BaseColor + Color;
 		}
-		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, SnappingClient);
+		Server()->SendPackMsg(&Msg, MSGFLAG_NORECORD, SnappingClient);
 
 		m_LoadedSkin = false;
 	}


### PR DESCRIPTION
Rainbow packets should not be vital, they get outdated next tick anyway.
Making them vital fills the ringbuffer (because they get resent), and create connection problems.