### PR TITLE
Fix SnapFreeID being called too much in pickup_drop, move it to a destructor

### DIFF
--- a/src/game/server/entities/pickup_drop.cpp
+++ b/src/game/server/entities/pickup_drop.cpp
@@ -33,6 +33,12 @@ CPickupDrop::CPickupDrop(CGameWorld *pGameWorld, vec2 Pos, int Type, int Owner, 
 	GameWorld()->InsertEntity(this);
 }
 
+CPickupDrop::~CPickupDrop()
+{
+	for (int i = 0; i < 4; i++)
+		Server()->SnapFreeID(m_aID[i]);
+}
+
 void CPickupDrop::Reset(bool Erase, bool Picked)
 {
 	if (Erase && m_Type == POWERUP_WEAPON)
@@ -47,29 +53,28 @@ void CPickupDrop::Reset(bool Erase, bool Picked)
 	if (!Picked)
 		GameServer()->CreateDeath(m_Pos, m_pOwner ? m_Owner : -1);
 
-	for (int i = 0; i < 4; i++)
-		Server()->SnapFreeID(m_aID[i]);
 	GameWorld()->DestroyEntity(this);
 }
 
 void CPickupDrop::Tick()
 {
+	bool DoReset = false;
 	m_pOwner = 0;
 	if (m_Owner != -1 && GameServer()->GetPlayerChar(m_Owner))
 		m_pOwner = GameServer()->GetPlayerChar(m_Owner);
 
 	if (m_Owner >= 0 && !GameServer()->m_apPlayers[m_Owner] && g_Config.m_SvDestroyDropsOnLeave)
-		Reset();
+		DoReset = true;
 
 	m_TeamMask = m_pOwner ? m_pOwner->Teams()->TeamMask(m_pOwner->Team(), -1, m_Owner) : -1LL;
 
 	// weapon hits death-tile or left the game layer, reset it
 	if (GameServer()->Collision()->GetCollisionAt(m_Pos.x, m_Pos.y) == TILE_DEATH || GameServer()->Collision()->GetFCollisionAt(m_Pos.x, m_Pos.y) == TILE_DEATH || GameLayerClipped(m_Pos))
-		Reset();
+		DoReset = true;
 
 	m_Lifetime--;
 	if (m_Lifetime <= 0)
-		Reset();
+		DoReset = true;
 
 	if (m_PickupDelay > 0)
 		m_PickupDelay--;
@@ -80,6 +85,8 @@ void CPickupDrop::Tick()
 	HandleDropped();
 
 	m_PrevPos = m_Pos;
+	if(DoReset) // only reset once
+		Reset();
 }
 
 void CPickupDrop::Pickup()

--- a/src/game/server/entities/pickup_drop.h
+++ b/src/game/server/entities/pickup_drop.h
@@ -10,6 +10,7 @@ class CPickupDrop : public CEntity
 {
 public:
 	CPickupDrop(CGameWorld *pGameWorld, vec2 Pos, int Type, int Owner, float Direction, int Weapon = WEAPON_GUN, int Lifetime = 300, int Bullets = -1, bool SpreadWeapon = false, bool Jetpack = false);
+	virtual ~CPickupDrop();
 
 	void Reset(bool Erase, bool Picked);
 	virtual void Reset() { Reset(true, false); };


### PR DESCRIPTION
- Made sure we only call `CPickupDrop::Reset()` once
- Moved the `SnapFreeID` code in the destructor anyway just to be sure