### PR TITLE
Add missing SnapFreeIDs on Dragger destruction (on world end)

### DIFF
--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -258,6 +258,14 @@ void CDragger::Drag()
 
 void CDragger::Reset()
 {
+	for (int i = 0; i < MAX_CLIENTS; i++)
+	{
+		if (m_SoloIDs[i] == -1)
+			break;
+
+		Server()->SnapFreeID(m_SoloIDs[i]);
+		m_SoloIDs[i] = -1;
+	}
 	GameServer()->m_World.DestroyEntity(this);
 }
 


### PR DESCRIPTION
When the world ends, all entities are reset, before they are removed:
https://github.com/fokkonaut/F-DDrace/blob/5aa0b4c126dac3b7bdf768d33f4ebaec73cf7f60/src/game/server/gameworld.cpp#L130-L139

This probably means that we are not going to free any snap IDs in use in `CDragger`, because `CDragger::Reset` only calls `DestroyEntity`, which is simply a fancy `delete this`.

I suggest to only merge this when crashes due to double-frees of snap IDs stop.