### PR TITLE
Give XP for upgrading jumps

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2076,7 +2076,7 @@ void CCharacter::HandleTiles(int Index)
 	if (((m_TileIndex == TILE_END) || (m_TileFIndex == TILE_END) || FTile1 == TILE_END || FTile2 == TILE_END || FTile3 == TILE_END || FTile4 == TILE_END || Tile1 == TILE_END || Tile2 == TILE_END || Tile3 == TILE_END || Tile4 == TILE_END) && m_DDRaceState == DDRACE_STARTED)
 	{
 		Controller->m_Teams.OnCharacterFinish(m_pPlayer->GetCID());
-		m_pPlayer->GiveXP(250, "finish the race");
+		m_pPlayer->GiveXP(500, "finish the race");
 	}
 
 	// freeze
@@ -2404,7 +2404,7 @@ void CCharacter::HandleTiles(int Index)
 		char aBuf[64];
 		str_format(aBuf, sizeof(aBuf), "'%s' finished the special race!", Server()->ClientName(m_pPlayer->GetCID()));
 		GameServer()->SendChat(-1, CHAT_ALL, -1, aBuf);
-		m_pPlayer->GiveXP(250, "finish the special race");
+		m_pPlayer->GiveXP(750, "finish the special race");
 
 		m_HasFinishedSpecialRace = true;
 	}

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2599,7 +2599,7 @@ void CCharacter::HandleTiles(int Index)
 				str_format(aBuf, sizeof(aBuf), "You can jump %d times", newJumps);
 			GameServer()->SendChatTarget(GetPlayer()->GetCID(), aBuf);
 			int XpBonus = newJumps > 2 ? (newJumps * 100) : 0;
-			if (XpBonus && newJumps > m_MaxJumps)
+			if (XpBonus && newJumps > m_MaxJumps && m_DDRaceState != DDRACE_CHEAT)
 				m_pPlayer->GiveXP(XpBonus, "upgrading jumps");
 
 			m_Core.m_Jumps = newJumps;

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2598,8 +2598,12 @@ void CCharacter::HandleTiles(int Index)
 			else
 				str_format(aBuf, sizeof(aBuf), "You can jump %d times", newJumps);
 			GameServer()->SendChatTarget(GetPlayer()->GetCID(), aBuf);
+			int XpBonus = newJumps > 2 ? (newJumps * 100) : 0;
+			if (XpBonus && newJumps > m_MaxJumps)
+				m_pPlayer->GiveXP(XpBonus, "upgrading jumps");
 
 			m_Core.m_Jumps = newJumps;
+			m_MaxJumps = max(m_MaxJumps, m_Core.m_Jumps);
 		}
 	}
 	else if (GameServer()->Collision()->IsSwitch(MapIndex) == TILE_PENALTY && !m_LastPenalty)
@@ -3194,6 +3198,7 @@ void CCharacter::FDDraceInit()
 	m_LastLinkedPortals = Now;
 	m_LastWantedWeapon = 0;
 	m_LastWantedLogout = 0;
+	m_MaxJumps = 0;
 }
 
 void CCharacter::FDDraceTick()

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2598,9 +2598,8 @@ void CCharacter::HandleTiles(int Index)
 			else
 				str_format(aBuf, sizeof(aBuf), "You can jump %d times", newJumps);
 			GameServer()->SendChatTarget(GetPlayer()->GetCID(), aBuf);
-			int XpBonus = newJumps > 2 ? (newJumps * 100) : 0;
-			if (XpBonus && newJumps > m_MaxJumps && m_DDRaceState != DDRACE_CHEAT)
-				m_pPlayer->GiveXP(XpBonus, "upgrading jumps");
+			if (newJumps > m_MaxJumps && m_DDRaceState != DDRACE_CHEAT)
+				m_pPlayer->GiveXP(newJumps * 100, "upgrading jumps");
 
 			m_Core.m_Jumps = newJumps;
 			m_MaxJumps = max(m_MaxJumps, m_Core.m_Jumps);
@@ -3198,7 +3197,7 @@ void CCharacter::FDDraceInit()
 	m_LastLinkedPortals = Now;
 	m_LastWantedWeapon = 0;
 	m_LastWantedLogout = 0;
-	m_MaxJumps = 0;
+	m_MaxJumps = m_Core.m_Jumps;
 }
 
 void CCharacter::FDDraceTick()

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -407,6 +407,7 @@ public:
 	bool m_IsRainbowHooked;
 
 	int m_SavedGamemode;
+	int m_MaxJumps;
 
 	// editor
 	CDrawEditor m_DrawEditor;


### PR DESCRIPTION
Reaching a 5 jumps tile gives 500 xp and 8 jumps 800 xp

Dowgrading and upgrading jumps does not give xp to avoid farming.
Only new jump highscores during lifetime of the tee give xp.