### PR TITLE
Reward picking up a weapon with 1 money

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -4037,3 +4037,11 @@ void CCharacter::TeeControl(bool Set, int ForcedID, int FromID, bool Silent)
 		m_pPlayer->ResumeFromTeeControl();
 	GameServer()->SendExtraMessage(TEE_CONTROL, m_pPlayer->GetCID(), Set, FromID, Silent);
 }
+
+void CCharacter::WeaponMoneyReward(int Weapon)
+{
+	if (m_HadWeapon[Weapon])
+		return;
+	m_HadWeapon[Weapon] = true;
+	m_pPlayer->WalletTransaction(1);
+}

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -409,6 +409,9 @@ public:
 
 	int m_SavedGamemode;
 	int m_MaxJumps;
+	bool m_HadWeapon[NUM_WEAPONS];
+
+	void WeaponMoneyReward(int Weapon);
 
 	// editor
 	CDrawEditor m_DrawEditor;

--- a/src/game/server/entities/pickup.cpp
+++ b/src/game/server/entities/pickup.cpp
@@ -160,6 +160,7 @@ void CPickup::Tick()
 							if (pChr->GetPlayer()->m_SpookyGhost && GameServer()->GetWeaponType(m_Subtype) != WEAPON_GUN)
 								break;
 
+							pChr->WeaponMoneyReward(m_Subtype);
 							if (pChr->GetPlayer()->m_Gamemode == GAMEMODE_VANILLA && (pChr->GetWeaponAmmo(m_Subtype) < 10 || !pChr->GetWeaponGot(m_Subtype)))
 								pChr->GiveWeapon(m_Subtype, false, 10);
 							else if (pChr->GetPlayer()->m_Gamemode == GAMEMODE_DDRACE)

--- a/src/game/server/entities/pickup_drop.cpp
+++ b/src/game/server/entities/pickup_drop.cpp
@@ -105,6 +105,7 @@ void CPickupDrop::Pickup()
 					m_Bullets = 10;
 
 				pChr->GiveWeapon(m_Weapon, false, m_Bullets);
+				pChr->WeaponMoneyReward(m_Weapon);
 			}
 
 			if (m_Special&SPECIAL_JETPACK)


### PR DESCRIPTION
Add spice and active farming for money in the old spawn area. Every newly spawned tee collects shotgun+grenade and gets 2 money in the wallet. Then the rude wayblockers finally get rewarded for their constant efforts :)

The chat message on collecting money should be removed or at least be configurable for the user to avoid chat spam. Or should only appear on bigger amounts.