### PR TITLE
Fix tee stack using minigames

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -97,7 +97,8 @@ bool CCharacter::Spawn(CPlayer *pPlayer, vec2 Pos)
 	GameServer()->m_pController->OnCharacterSpawn(this);
 	Teams()->OnCharacterSpawn(GetPlayer()->GetCID());
 	DDraceInit();
-	m_pPlayer->LoadMinigameTee();
+	if (m_pPlayer->LoadMinigameTee())
+		m_Core.m_Vel.y = -2.f;
 
 	m_TuneZone = GameServer()->Collision()->IsTune(GameServer()->Collision()->GetMapIndex(Pos));
 	m_TuneZoneOld = -1; // no zone leave msg on spawn


### PR DESCRIPTION
Using /minigame and /leave allowed tees to stack in the same moneytile

Tested ingame. Now it creates a tower and the initial bounce can be abused to do jumps for example in freeze or similar. But i think that is better than adding a x vel that would destroy existing towers. So you can do a tee tower in freeze and enter minigames without worrying about the tower.