### PR TITLE
Make m_WalletMoney read only

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1310,7 +1310,7 @@ void CGameContext::ConStats(IConsole::IResult* pResult, void* pUserData)
 			pSelf->SendChatTarget(pResult->m_ClientID, aBuf);
 			str_format(aBuf, sizeof(aBuf), "Bank [%lld]", pAccount->m_Money);
 			pSelf->SendChatTarget(pResult->m_ClientID, aBuf);
-			str_format(aBuf, sizeof(aBuf), "Wallet [%lld]", pPlayer->m_WalletMoney);
+			str_format(aBuf, sizeof(aBuf), "Wallet [%lld]", pPlayer->GetWalletMoney());
 			pSelf->SendChatTarget(pResult->m_ClientID, aBuf);
 			str_format(aBuf, sizeof(aBuf), "Police [%d]%s", pAccount->m_PoliceLevel, pAccount->m_PoliceLevel >= NUM_POLICE_LEVELS ? " (max)" : "");
 			pSelf->SendChatTarget(pResult->m_ClientID, aBuf);
@@ -1844,7 +1844,7 @@ void CGameContext::ConMoney(IConsole::IResult* pResult, void* pUserData)
 				pSelf->SendChatTarget(pResult->m_ClientID, "You can't drop money bags over 100.000");
 				return;
 			}
-			if (Amount > pPlayer->m_WalletMoney)
+			if (Amount > pPlayer->GetWalletMoney())
 			{
 				pSelf->SendChatTarget(pResult->m_ClientID, "You don't have enough money in your wallet");
 				return;
@@ -1863,7 +1863,7 @@ void CGameContext::ConMoney(IConsole::IResult* pResult, void* pUserData)
 	pSelf->SendChatTarget(pResult->m_ClientID, "~~~~~~~~~~");
 	str_format(aBuf, sizeof(aBuf), "Bank: %lld", pSelf->m_Accounts[pPlayer->GetAccID()].m_Money);
 	pSelf->SendChatTarget(pResult->m_ClientID, aBuf);
-	str_format(aBuf, sizeof(aBuf), "Wallet: %lld", pPlayer->m_WalletMoney);
+	str_format(aBuf, sizeof(aBuf), "Wallet: %lld", pPlayer->GetWalletMoney());
 	pSelf->SendChatTarget(pResult->m_ClientID, aBuf);
 	str_format(aBuf, sizeof(aBuf), "Euros: %d", pSelf->m_Accounts[pPlayer->GetAccID()].m_Euros);
 	pSelf->SendChatTarget(pResult->m_ClientID, aBuf);
@@ -1982,7 +1982,7 @@ void CGameContext::ConSpawn(IConsole::IResult* pResult, void* pUserData)
 		return;
 	}
 
-	if (pPlayer->m_WalletMoney < 50000)
+	if (pPlayer->GetWalletMoney() < 50000)
 	{
 		pSelf->SendChatTarget(pResult->m_ClientID, "You don't have enough money");
 		return;
@@ -2113,7 +2113,7 @@ void CGameContext::ConPlot(IConsole::IResult* pResult, void* pUserData)
 			return;
 		}
 
-		if (pPlayer->m_WalletMoney < Price)
+		if (pPlayer->GetWalletMoney() < Price)
 		{
 			pSelf->SendChatTarget(pResult->m_ClientID, "You don't have enough money");
 			return;

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2370,7 +2370,7 @@ void CCharacter::HandleTiles(int Index)
 						"Money [%lld] +1%s%s\n"
 						"XP [%d/%d]%s\n"
 						"Level [%d]",
-						m_pPlayer->m_WalletMoney, (PoliceMoneyTile && pAccount->m_PoliceLevel) ? aPolice : "", pAccount->m_VIP ? " +2 vip" : "",
+						m_pPlayer->GetWalletMoney(), (PoliceMoneyTile && pAccount->m_PoliceLevel) ? aPolice : "", pAccount->m_VIP ? " +2 vip" : "",
 						pAccount->m_XP, GameServer()->GetNeededXP(pAccount->m_Level), aPlusXP,
 						pAccount->m_Level
 					);
@@ -3498,7 +3498,7 @@ bool CCharacter::IsFreeDraw()
 
 void CCharacter::DropMoney(int64 Amount, int Dir)
 {
-	if (Amount <= 0 || Amount > m_pPlayer->m_WalletMoney)
+	if (Amount <= 0 || Amount > m_pPlayer->GetWalletMoney())
 		return;
 
 	if (Dir == -3)
@@ -3612,7 +3612,7 @@ void CCharacter::DropLoot(int Weapon)
 
 	// Drop money even if killed by the game, e.g. team change or minigame change
 	if (m_FreezeTime)
-		DropMoney(m_pPlayer->m_WalletMoney);
+		DropMoney(m_pPlayer->GetWalletMoney());
 
 	if (Weapon == WEAPON_GAME)
 		return;

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4668,11 +4668,11 @@ void CGameContext::SaveOrDropWallet()
 		// If player is not logged we just drop it so it will get reloaded after reload or on next server start
 		if (pPlayer->GetAccID() >= ACC_START)
 		{
-			pPlayer->BankTransaction(pPlayer->m_WalletMoney, "automatic wallet to bank due to shutdown");
-			pPlayer->WalletTransaction(-pPlayer->m_WalletMoney);
+			pPlayer->BankTransaction(pPlayer->GetWalletMoney(), "automatic wallet to bank due to shutdown");
+			pPlayer->WalletTransaction(-pPlayer->GetWalletMoney());
 		}
 		else if (pPlayer->GetCharacter())
-			pPlayer->GetCharacter()->DropMoney(pPlayer->m_WalletMoney);
+			pPlayer->GetCharacter()->DropMoney(pPlayer->GetWalletMoney());
 	}
 }
 

--- a/src/game/server/houses/bank.cpp
+++ b/src/game/server/houses/bank.cpp
@@ -66,7 +66,7 @@ void CBank::OnSuccess(int ClientID)
 	char aMsg[128];
 	if (m_aAssignmentMode[ClientID] == ASSIGNMENT_DEPOSIT)
 	{
-		if (pPlayer->m_WalletMoney < Amount)
+		if (pPlayer->GetWalletMoney() < Amount)
 		{
 			GameServer()->SendChatTarget(ClientID, "You don't have enough money in your wallet to deposit this amount.");
 			return;
@@ -122,7 +122,7 @@ void CBank::OnPageChange(int ClientID)
 	{
 		pFooter = "Press F3 to confirm your assignment.";
 		const char *pAssignment = m_aAssignmentMode[ClientID] == ASSIGNMENT_DEPOSIT ? "D E P O S I T" : m_aAssignmentMode[ClientID] == ASSIGNMENT_WITHDRAW ? "W I T H D R A W" : "";
-		str_format(aMsg, sizeof(aMsg), "Bank: %lld\nWallet: %lld\n\n%s\n\n", GameServer()->m_Accounts[GameServer()->m_apPlayers[ClientID]->GetAccID()].m_Money, GameServer()->m_apPlayers[ClientID]->m_WalletMoney, pAssignment);
+		str_format(aMsg, sizeof(aMsg), "Bank: %lld\nWallet: %lld\n\n%s\n\n", GameServer()->m_Accounts[GameServer()->m_apPlayers[ClientID]->GetAccID()].m_Money, GameServer()->m_apPlayers[ClientID]->GetWalletMoney(), pAssignment);
 
 		char aAmount[64];
 		int Type = m_aClients[ClientID].m_Page;
@@ -151,7 +151,7 @@ int CBank::GetAmount(int Type, int ClientID)
 				return 0;
 
 			if (m_aAssignmentMode[ClientID] == ASSIGNMENT_DEPOSIT)
-				return pPlayer->m_WalletMoney;
+				return pPlayer->GetWalletMoney();
 			else if (m_aAssignmentMode[ClientID] == ASSIGNMENT_WITHDRAW)
 				return GameServer()->m_Accounts[pPlayer->GetAccID()].m_Money;
 		}

--- a/src/game/server/houses/shop.cpp
+++ b/src/game/server/houses/shop.cpp
@@ -329,7 +329,7 @@ void CShop::BuyItem(int ClientID, int Item)
 
 	// check for the correct price
 	if ((m_aItems[ItemID].m_IsEuro && pAccount->m_Euros < Price)
-		|| (!m_aItems[ItemID].m_IsEuro && pPlayer->m_WalletMoney < Price))
+		|| (!m_aItems[ItemID].m_IsEuro && pPlayer->GetWalletMoney() < Price))
 	{
 		GameServer()->SendChatTarget(ClientID, "You don't have enough money");
 		return;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -725,7 +725,7 @@ void CPlayer::OnDisconnect()
 {
 	// Make sure to call this before the character dies because on disconnect it should drop the money even when frozen
 	if (GameServer()->Config()->m_SvDropsOnDeath && m_pCharacter)
-		m_pCharacter->DropMoney(m_WalletMoney);
+		m_pCharacter->DropMoney(GetWalletMoney());
 	KillCharacter();
 
 	GameServer()->Logout(GetAccID());

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -336,7 +336,7 @@ public:
 	void BankTransaction(int64 Amount, const char *pDescription = "", bool IsEuro = false);
 	void WalletTransaction(int64 Amount, const char *pDescription = "");
 	void ApplyMoneyHistoryMsg(int Type, int Amount, const char *pDescription);
-	int64 m_WalletMoney;
+	int64 GetWalletMoney() { return m_WalletMoney; }
 
 	// plot
 	void CancelPlotAuction();
@@ -402,6 +402,9 @@ public:
 	void SetFakeID();
 	int m_FakeID;
 	bool m_aSameIP[MAX_CLIENTS];
+
+private:
+	int64 m_WalletMoney;
 };
 
 #endif


### PR DESCRIPTION
this encapsulation ensures that m_WalletMoney is not written to directly
so moneyhistory is always written even if future coders are drunk