### PR TITLE
Do not allow joining minigames while being frozen

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -5780,6 +5780,12 @@ void CGameContext::SetMinigame(int ClientID, int Minigame, bool Force)
 	}
 
 	CCharacter *pChr = GetPlayerChar(ClientID);
+	if (pChr && pChr->m_FreezeTime)
+	{
+		SendChatTarget(ClientID, "You can not join minigames while being frozen");
+		return;
+	}
+
 	if (!Force && (!pChr || pChr->RequestMinigameChange(Minigame)))
 		return;
 


### PR DESCRIPTION
Fixes minigame meta to avoid being spiked/deeped or similar