### PR TITLE
Fix police bot stuck on edge pre police base

### DIFF
--- a/src/game/server/entities/dummy/blmapchill_police.cpp
+++ b/src/game/server/entities/dummy/blmapchill_police.cpp
@@ -166,7 +166,7 @@ void CDummyBlmapChillPolice::OldPoliceMoves()
 			}
 
 			// check for fail position
-			if ((RAW_Y > RAW(441) + 10 && (X > 402 || RAW_X < RAW(399) + 10)) || m_pCharacter->m_IsFrozen)
+			if ((RAW_Y > RAW(441) + 10 && (X > 402 || RAW_X < RAW(399) + 10)) || IsFrozen())
 				m_LowerPanic = 1; // lower panic mode to reposition
 		}
 	}
@@ -402,7 +402,7 @@ void CDummyBlmapChillPolice::OnTick()
 	}
 	else if (X < 240 && Y < 36) // the complete zone in the map intselfs. its for resetting the dummy when he is back in spawn using tp
 	{
-		if (m_pCharacter->m_IsFrozen && X > 32)
+		if (IsFrozen() && X > 32)
 		{
 			if (TicksPassed(60))
 				GameServer()->SendEmoticon(m_pPlayer->GetCID(), EMOTICON_DROP); // tear emote before killing
@@ -608,7 +608,7 @@ void CDummyBlmapChillPolice::OnTick()
 			}
 		}
 	}
-	if (m_pCharacter->m_IsFrozen && Y < 410) // kills when in freeze and not in policebase
+	if (IsFrozen() && Y < 410) // kills when in freeze and not in policebase
 	{
 		if (TicksPassed(60))
 			GameServer()->SendEmoticon(m_pPlayer->GetCID(), EMOTICON_DROP); // tear emote before killing
@@ -618,7 +618,7 @@ void CDummyBlmapChillPolice::OnTick()
 			return;
 		}
 	}
-	if (m_pCharacter->m_IsFrozen && X < 41 && X > 33 && Y < 10) // kills when on speedup right next to the newtee spawn to prevent infinite flappy blocking
+	if (IsFrozen() && X < 41 && X > 33 && Y < 10) // kills when on speedup right next to the newtee spawn to prevent infinite flappy blocking
 	{
 		if (TicksPassed(500)) // kill when freeze
 		{
@@ -925,7 +925,7 @@ void CDummyBlmapChillPolice::OnTick()
 			SetWeapon(WEAPON_GUN);
 	}
 	// after grenade jump and being down going into the tunnel to police staion
-	else if (Y > 328 && Y < 345 && X > 236 && X < 365)
+	else if (Y > 328 && Y < 346 && X > 236 && X < 365)
 	{
 		Right();
 		if (X > 265 && X < 267)
@@ -935,10 +935,37 @@ void CDummyBlmapChillPolice::OnTick()
 		// walk left in air to get on the little block
 		if (Y > 337.4f && X > 295)
 			Left();
+		// fix someone blocking flappy, he would just keep moving left into the wall and do nothing there
+		if (X > 294 && X < 297 && Y > 343 && Y < 345 && (IsGrounded() || GetVel().y < -1.1f))
+			m_GetSpeed = true;
+		if (m_GetSpeed)
+		{
+			if (X < 290)
+				m_GetSpeed = false;
+			Left();
+			if (Y > 337)
+			{
+				// rj the wall up
+				Aim(-200, 280);
+				if (TicksPassed(10))
+					SetWeapon(WEAPON_GRENADE);
+				if (GetVel().y > -4.1f && IsGrounded())
+					Jump(rand() % 3);
+				else if (GetVel().y > -1.5f)
+					Fire();
+			}
+			else
+			{
+				// avoid roof freeze
+				Aim(1, -200);
+				if (Y < 331)
+					Fire();
+			}
+		}
+		// reset get speed when falling through the freeze for next part
+		if (IsFrozen())
+			m_GetSpeed = false;
 	}
-	// fix someone blocking flappy, he would just keep moving left into the wall and do nothing there
-	else if (X > 294 && X < 297 && Y > 343 && Y < 345)
-		Right();
 	else if (Y < 361 && Y > 346)
 	{
 		if (TicksPassed(10))
@@ -980,7 +1007,7 @@ void CDummyBlmapChillPolice::OnTick()
 	else if (X > 180 && X < 450 && Y < 450 && Y > 358) // wider police area with left entrance
 	{
 		// kills when in freeze in policebase or left of it (takes longer that he kills bcs the way is so long he wait a bit longer for help)
-		if (m_pCharacter->m_IsFrozen)
+		if (IsFrozen())
 		{
 			if (TicksPassed(60))
 				GameServer()->SendEmoticon(m_pPlayer->GetCID(), EMOTICON_DROP); // tear emote before killing

--- a/src/game/server/entities/dummy/dummybase.cpp
+++ b/src/game/server/entities/dummy/dummybase.cpp
@@ -55,6 +55,12 @@ CDummyBase::CDummyBase(CCharacter *pChr, int Mode)
 	m_Mode = Mode;
 	m_DebugColor = -1;
 	m_WantedWeapon = -1;
+	m_RtfGetSpeed = 0;
+	m_LtfGetSpeed = 0;
+	m_GoSlow = false;
+	m_AsBackwards = false;
+	m_AsTopFree = false;
+	m_AsBottomFree = false;
 }
 
 void CDummyBase::Tick()
@@ -211,23 +217,83 @@ void CDummyBase::AvoidFreezeWeapons()
 
 void CDummyBase::RightAntiStuck()
 {
-	Right();
-	if (GameServer()->Collision()->IntersectLine(GetPos(), vec2(RAW_X + 60, RAW_Y), 0, 0))
-	{
-		Jump(random(5));
-		if(GameServer()->Collision()->IntersectLine(GetPos(), vec2(RAW_X + 10, RAW_Y + 60), 0, 0))
-			Left();
-	}
+	AntiStuckDir(DIRECTION_RIGHT);
 }
 
 void CDummyBase::LeftAntiStuck()
 {
-	Left();
-	if (GameServer()->Collision()->IntersectLine(GetPos(), vec2(RAW_X - 60, RAW_Y), 0, 0))
+	AntiStuckDir(DIRECTION_LEFT);
+}
+
+void CDummyBase::AntiStuckDir(int Direction)
+{
+	SetDirection(Direction);
+	if (m_GoSlow)
+	{
+		StopMoving();
+		if(TicksPassed(3))
+			SetDirection(Direction);
+		if (TicksPassed(200))
+			m_GoSlow = false;
+		if (m_AsTopFree)
+			Jump(random(5));
+		return;
+	}
+	if (m_AsBackwards)
+	{
+		SetDirection(-Direction);
+		m_AsTopFree = !GameServer()->Collision()->IsSolid(RAW_X + 20 * Direction, RAW_Y - 20) &&
+				!GameServer()->Collision()->IsSolid(RAW_X + 20 * Direction, RAW_Y - 40) &&
+				!GameServer()->Collision()->IsSolid(RAW_X + 20 * Direction, RAW_Y - 70);
+		m_AsBottomFree = !GameServer()->Collision()->IsSolid(RAW_X + 20 * Direction, RAW_Y + 20) &&
+				!GameServer()->Collision()->IsSolid(RAW_X + 20 * Direction, RAW_Y + 40) &&
+				!GameServer()->Collision()->IsSolid(RAW_X + 20 * Direction, RAW_Y + 70);
+		if (m_AsTopFree || m_AsBottomFree)
+		{
+			Jump(random(5));
+			m_AsBackwards = false;
+			if (m_AsTopFree && !GameServer()->Collision()->IsSolid(RAW_X - 20 * Direction, RAW_Y - 20))
+			{
+				// when there is space go fast
+			}
+			else
+			{
+				m_GoSlow = true;
+			}
+		}
+		return;
+	}
+	if (GameServer()->Collision()->IsSolid(RAW_X + 60 * Direction, RAW_Y) ||
+		GameServer()->Collision()->IsSolid(RAW_X + 30 * Direction, RAW_Y) ||
+		GameServer()->Collision()->IsSolid(RAW_X + 10 * Direction, RAW_Y))
 	{
 		Jump(random(5));
-		if(GameServer()->Collision()->IntersectLine(GetPos(), vec2(RAW_X - 10, RAW_Y - 60), 0, 0))
-			Right();
+		// too slow? Check if in a dead end
+		if(((Direction == DIRECTION_LEFT && GetVel().x > -1.1f) || (Direction == DIRECTION_RIGHT && GetVel().x < 1.1f)) && IsGrounded())
+		{
+			if(
+				/* top blocked */
+				(
+					GameServer()->Collision()->IsSolid(RAW_X + 10 * Direction, RAW_Y - 20) ||
+					GameServer()->Collision()->IsSolid(RAW_X + 10 * Direction, RAW_Y - 40) ||
+					GameServer()->Collision()->IsSolid(RAW_X + 10 * Direction, RAW_Y - 70)
+				) &&
+				/* bottom blocked */
+				(
+					GameServer()->Collision()->IsSolid(RAW_X + 10 * Direction, RAW_Y + 20) ||
+					GameServer()->Collision()->IsSolid(RAW_X + 10 * Direction, RAW_Y + 40) ||
+					GameServer()->Collision()->IsSolid(RAW_X + 10 * Direction, RAW_Y + 70)
+				) &&
+				/* left blocked */
+				(
+					GameServer()->Collision()->IsSolid(RAW_X + 20 * Direction, RAW_Y - 30) ||
+					GameServer()->Collision()->IsSolid(RAW_X + 20 * Direction, RAW_Y + 30)
+				)
+			)
+			{
+				m_AsBackwards = true;
+			}
+		}
 	}
 }
 

--- a/src/game/server/entities/dummy/dummybase.cpp
+++ b/src/game/server/entities/dummy/dummybase.cpp
@@ -17,6 +17,7 @@ int CDummyBase::Jumped() { return m_pCharacter->Core()->m_Jumped; }
 int CDummyBase::JumpedTotal() { return m_pCharacter->Core()->m_JumpedTotal; }
 int CDummyBase::Jumps() { return m_pCharacter->Core()->m_Jumps; }
 bool CDummyBase::IsGrounded() { return m_pCharacter->IsGrounded(); }
+bool CDummyBase::IsFrozen() { return m_pCharacter->m_IsFrozen; }
 int CDummyBase::GetTargetX() { return m_pCharacter->Input()->m_TargetX; }
 int CDummyBase::GetTargetY() { return m_pCharacter->Input()->m_TargetY; }
 int CDummyBase::GetDirection() { return m_pCharacter->Input()->m_Direction; }

--- a/src/game/server/entities/dummy/dummybase.h
+++ b/src/game/server/entities/dummy/dummybase.h
@@ -36,6 +36,10 @@ private:
 
 	int m_RtfGetSpeed;
 	int m_LtfGetSpeed;
+	bool m_GoSlow;
+	bool m_AsBackwards;
+	bool m_AsTopFree;
+	bool m_AsBottomFree;
 
 protected:
 	CGameContext *GameServer() const;
@@ -97,6 +101,7 @@ protected:
 	void AvoidTile(int Tile);
 	void AvoidFreeze();
 	void AvoidDeath();
+	void AntiStuckDir(int Direction);
 
 	/*
 		Function: AvoidFreezeWeapons

--- a/src/game/server/entities/dummy/dummybase.h
+++ b/src/game/server/entities/dummy/dummybase.h
@@ -72,6 +72,7 @@ protected:
 	int JumpedTotal();
 	int Jumps();
 	bool IsGrounded();
+	bool IsFrozen();
 
 	int GetTargetX();
 	int GetTargetY();


### PR DESCRIPTION
Heavily extended the base class anti stuck walker. Even tho the code looks more bloated it was written with performance in mind so it has less collision checks due to no iterations and condition nesting. It is no longer possible to squeeze the bot into a chair and let him stuck there. Furthermore it can now detect dead ends better and after some tries pass through annoying 1 tilers. Its no pathfinder but simple one directional ways including basic chairs and tables can be bypassed easily.

https://zillyhuhn.com/OpenTube/video.php?t=AntiStuckDir.mp4&u=fddrace