### PR TITLE
Add /money drop all and /money drop 10k

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1958,6 +1958,10 @@ void CGameContext::ConMoney(IConsole::IResult* pResult, void* pUserData)
 		if (pPlayer->GetCharacter())
 		{
 			int Amount = pResult->GetInteger(1);
+			if(!str_comp(pResult->GetString(1), "all"))
+				Amount = pPlayer->GetWalletMoney();
+			if(*(pResult->GetString(1) + str_length(pResult->GetString(1)) - 1) == 'k')
+				Amount *= 1000;
 			if (Amount <= 0)
 			{
 				pSelf->SendChatTarget(pResult->m_ClientID, "You can't drop nothing");


### PR DESCRIPTION
Biggest use case for /money drop is sending all money to dummy and go to bank. Thats why "/money drop all" can be handy. Also typing out all the zeros can be skipped with the kilo notation. For example "/money drop 10k" to drop 10 000.