### PR TITLE
Fix std::size build error

### DIFF
--- a/src/engine/server/register.cpp
+++ b/src/engine/server/register.cpp
@@ -11,6 +11,9 @@
 #include <engine/shared/packer.h>
 #include <engine/shared/uuid_manager.h>
 
+#include <iostream> // for std::cout
+#include <iterator> // for std::size
+
 class CRegister : public IRegister
 {
 	enum


### PR DESCRIPTION
fixes
```
/home/chiller/Desktop/git/F-DDrace/src/engine/server/register.cpp: In member function ‘virtual void CRegister::OnConfigChange()’:
/home/chiller/Desktop/git/F-DDrace/src/engine/server/register.cpp:610:51: error: ‘size’ is not a member of ‘std’
  610 |                 if(m_NumExtraHeaders == (int)std::size(m_aaExtraHeaders))
      |                                                   ^~~~

```