### PR TITLE
clear_votes crash fix

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3618,6 +3618,9 @@ void CGameContext::ConClearVotes(IConsole::IResult *pResult, void *pUserData)
 	pSelf->m_pVoteOptionLast = 0;
 	pSelf->m_NumVoteOptions = 0;
 
+	if(!pSelf->m_VotingMenu.IsInitialized())
+		return;
+
 	// Reset so the votes get added again
 	pSelf->m_VotingMenu.AddPlaceholderVotes();
 

--- a/src/game/server/votingmenu.h
+++ b/src/game/server/votingmenu.h
@@ -170,6 +170,7 @@ public:
 	void SetWantedPlayer(int ClientID) { m_vWantedPlayers.push_back(ClientID); }
 	void ApplyFlags(int ClientID, int Flags);
 	int GetFlags(int ClientID);
+	bool IsInitialized() { return m_Initialized; }
 
 	enum
 	{


### PR DESCRIPTION
clear_votes in autoexec config crash server because m_pGameServer not initialized yet in CVotingMenu. 